### PR TITLE
Minor changes

### DIFF
--- a/btcpay-greenfield-for-woocommerce.php
+++ b/btcpay-greenfield-for-woocommerce.php
@@ -7,12 +7,12 @@
  * Author URI:      https://btcpayserver.org
  * Text Domain:     btcpay-greenfield-for-woocommerce
  * Domain Path:     /languages
- * Version:         2.5.0
- * Requires PHP:    7.4
+ * Version:         2.6.0
+ * Requires PHP:    8.0
  * Tested up to:    6.4
- * Requires at least: 5.2
+ * Requires at least: 5.9
  * WC requires at least: 6.0
- * WC tested up to: 8.5
+ * WC tested up to: 8.6
  */
 
 use BTCPayServer\WC\Admin\Notice;
@@ -26,7 +26,7 @@ use BTCPayServer\WC\Helper\Logger;
 
 defined( 'ABSPATH' ) || exit();
 
-define( 'BTCPAYSERVER_VERSION', '2.5.0' );
+define( 'BTCPAYSERVER_VERSION', '2.6.0' );
 define( 'BTCPAYSERVER_VERSION_KEY', 'btcpay_gf_version' );
 define( 'BTCPAYSERVER_PLUGIN_FILE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'BTCPAYSERVER_PLUGIN_URL', plugin_dir_url(__FILE__ ) );
@@ -39,7 +39,7 @@ class BTCPayServerWCPlugin {
 	public function __construct() {
 		$this->includes();
 
-		add_action('woocommerce_thankyou_btcpaygf_default', ['BTCPayServerWCPlugin', 'orderStatusThankYouPage'], 10, 1);
+		add_action( 'woocommerce_thankyou_btcpaygf_default', ['BTCPayServerWCPlugin', 'orderStatusThankYouPage'], 10, 1);
 		add_action( 'wp_ajax_btcpaygf_modal_checkout', [$this, 'processAjaxModalCheckout'] );
 		add_action( 'wp_ajax_btcpaygf_notifications', [$this, 'processAjaxNotification'] );
 		add_action( 'wp_ajax_nopriv_btcpaygf_modal_checkout', [$this, 'processAjaxModalCheckout'] );
@@ -151,8 +151,8 @@ class BTCPayServerWCPlugin {
 	 */
 	public function dependenciesNotification() {
 		// Check PHP version.
-		if ( version_compare( PHP_VERSION, '7.4', '<' ) ) {
-			$versionMessage = sprintf( __( 'Your PHP version is %s but BTCPay Greenfield Payment plugin requires version 7.4+.', 'btcpay-greenfield-for-woocommerce' ), PHP_VERSION );
+		if ( version_compare( PHP_VERSION, '8.0', '<' ) ) {
+			$versionMessage = sprintf( __( 'Your PHP version is %s but BTCPay Greenfield Payment plugin requires version 8.0+.', 'btcpay-greenfield-for-woocommerce' ), PHP_VERSION );
 			Notice::addNotice('error', $versionMessage);
 		}
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     }
   ],
   "require": {
-    "btcpayserver/btcpayserver-greenfield-php": "^1.0.0"
+    "btcpayserver/btcpayserver-greenfield-php": "^2.0.0"
   }
 }

--- a/languages/btcpay-greenfield-for-woocommerce.pot
+++ b/languages/btcpay-greenfield-for-woocommerce.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the BTCPay For Woocommerce V2 plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: BTCPay For Woocommerce V2 2.4.1\n"
+"Project-Id-Version: BTCPay For Woocommerce V2 2.6.0\n"
 "Report-Msgid-Bugs-To: https://woocommerce.com/my-account/create-a-ticket/\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2024-01-31T10:40:12+00:00\n"
+"POT-Creation-Date: 2024-02-27T13:45:12+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.9.0\n"
 "language-team: LANGUAGE <EMAIL@ADDRESS>\n"
@@ -40,7 +40,7 @@ msgid "Plugin not configured yet, please %1$sconfigure the plugin here%2$s"
 msgstr ""
 
 #: btcpay-greenfield-for-woocommerce.php:155
-msgid "Your PHP version is %s but BTCPay Greenfield Payment plugin requires version 7.4+."
+msgid "Your PHP version is %s but BTCPay Greenfield Payment plugin requires version 8.0+."
 msgstr ""
 
 #: btcpay-greenfield-for-woocommerce.php:161
@@ -101,6 +101,18 @@ msgstr ""
 msgid "Error processing the data from BTCPay. Please try again."
 msgstr ""
 
+#: generated/BTCPay_GF_BTC.php:25
+#: generated/BTCPay_GF_BTC_LightningNetwork.php:25
+#: generated/BTCPay_GF_BTC_LNURLPAY.php:25
+msgid "Token type"
+msgstr ""
+
+#: generated/BTCPay_GF_BTC.php:32
+#: generated/BTCPay_GF_BTC_LightningNetwork.php:32
+#: generated/BTCPay_GF_BTC_LNURLPAY.php:32
+msgid "Tokens of type promotion will not have a FIAT (USD, EUR, ..) exchange rate but counted as 1 per item quantity. See <a target=\"_blank\" href=\"https://docs.btcpayserver.org/FAQ/Integrations/#token-types\">here</a> for more details."
+msgstr ""
+
 #: src/Admin/GlobalSettings.php:24
 msgid "BTCPay Settings"
 msgstr ""
@@ -157,7 +169,7 @@ msgstr ""
 
 #: src/Admin/GlobalSettings.php:117
 msgctxt "global_settings"
-msgid "e.g. https://btcpayserver.example.com"
+msgid "https://mainnet.demo.btcpayserver.org"
 msgstr ""
 
 #: src/Admin/GlobalSettings.php:122
@@ -415,78 +427,78 @@ msgstr ""
 msgid "Insert image"
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:397
+#: src/Gateway/AbstractGateway.php:409
 msgctxt "js"
 msgid "The invoice expired. Please try again, choose a different payment method or contact us if you paid but the payment did not confirm in time."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:398
+#: src/Gateway/AbstractGateway.php:410
 msgctxt "js"
 msgid "Payment aborted by you. Please try again or choose a different payment method."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:399
+#: src/Gateway/AbstractGateway.php:411
 msgctxt "js"
 msgid "Error processing checkout. Please try again or choose another payment option."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:495
+#: src/Gateway/AbstractGateway.php:493
 msgid "Webhook (%s) received from BTCPay, but the order is already processing or completed, skipping to update order status. Please manually check if everything is alright."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:507
+#: src/Gateway/AbstractGateway.php:505
 msgid "Invoice (partial) payment incoming (unconfirmed) after invoice was already expired."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:510
+#: src/Gateway/AbstractGateway.php:508
 msgid "Invoice (partial) payment incoming (unconfirmed). Waiting for settlement."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:529
+#: src/Gateway/AbstractGateway.php:527
 msgid "Invoice fully settled after invoice was already expired. Needs manual checking."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:534
+#: src/Gateway/AbstractGateway.php:532
 msgid "(Partial) payment settled but invoice not settled yet (could be more transactions incoming). Needs manual checking."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:538
+#: src/Gateway/AbstractGateway.php:536
 msgid "Invoice (partial) payment settled."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:548
+#: src/Gateway/AbstractGateway.php:546
 msgid "Invoice payment received fully with overpayment, waiting for settlement."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:550
+#: src/Gateway/AbstractGateway.php:548
 msgid "Invoice payment received fully, waiting for settlement."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:556
+#: src/Gateway/AbstractGateway.php:554
 msgid "Invoice manually marked invalid."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:558
+#: src/Gateway/AbstractGateway.php:556
 msgid "Invoice became invalid."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:564
+#: src/Gateway/AbstractGateway.php:562
 msgid "Invoice expired but was paid partially, please check."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:567
+#: src/Gateway/AbstractGateway.php:565
 msgid "Invoice expired."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:573
+#: src/Gateway/AbstractGateway.php:571
 msgid "Invoice payment settled but was overpaid."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:576
+#: src/Gateway/AbstractGateway.php:574
 msgid "Invoice payment settled."
 msgstr ""
 
-#: src/Gateway/AbstractGateway.php:619
+#: src/Gateway/AbstractGateway.php:617
 msgid "BTCPay invoice manually set to invalid because customer went back to checkout and changed payment gateway."
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Bitcoin, Lightning Network, BTCPay Server, WooCommerce, payment gateway, a
 Requires at least: 5.2
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 2.5.0
+Stable tag: 2.6.0
 License: MIT
 License URI: https://github.com/btcpayserver/woocommerce-greenfield-plugin/blob/master/license.txt
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://btcpayserver.org/donate/
 Tags: Bitcoin, Lightning Network, BTCPay Server, WooCommerce, payment gateway, accept Bitcoin, Cryptocurrency, Crypto
 Requires at least: 5.2
 Tested up to: 6.4
-Requires PHP: 7.4
+Requires PHP: 8.0
 Stable tag: 2.6.0
 License: MIT
 License URI: https://github.com/btcpayserver/woocommerce-greenfield-plugin/blob/master/license.txt
@@ -111,10 +111,15 @@ You'll find extensive documentation and answers to many of your questions on [BT
 6. On BTCPay Server you have extensive reporting and accounting features.
 
 == Upgrade Notice ==
-= 2.5.0 =
-* New feature: Added support for modal checkout with [WooCommerce checkout blocks](https://woo.com/document/cart-checkout-blocks-status/).
+= 2.6.0 =
+* Important: Minimum PHP version is now 8.0
 
 == Changelog ==
+= 2.6.0 :: 2024-02-27 =
+* Update PHP BTCPay library to 2.3.0, minimum PHP version 8.0.
+* Show warning when .local domain is used for BTCPay Server URL.
+* Change BTCPay Server URL placeholder to official demo server.
+
 = 2.5.0 :: 2024-01-31 =
 * Fix: Formatting in readme.txt
 * Add support for modal overlay for checkout blocks.

--- a/resources/js/backend/apiKeyRedirect.js
+++ b/resources/js/backend/apiKeyRedirect.js
@@ -5,6 +5,10 @@ jQuery(document).ready(function($) {
 			if (url.protocol !== 'https:' && url.protocol !== 'http:') {
 				return false;
 			}
+			if (url.hostname.endsWith('.local')) {
+				alert('You entered a .local domain which only works on your local network. Please make sure your BTCPay Server is reachable on the internet if you want to use it in production. Check the tooltip for this field for more information. Aborting.');
+				return false;
+			}
 		} catch (e) {
 			console.error(e);
 			return false;

--- a/src/Admin/GlobalSettings.php
+++ b/src/Admin/GlobalSettings.php
@@ -114,7 +114,7 @@ class GlobalSettings extends \WC_Settings_Page {
 				),
 				'type' => 'text',
 				'desc' => esc_html_x( 'URL/host to your BTCPay Server instance. Note: if you use a self hosted node like Umbrel, RaspiBlitz, myNode, etc. you will have to make sure your node is reachable from the internet. You can do that through <a href="https://docs.btcpayserver.org/Deployment/ReverseProxyToTor/" target="_blank">Tor</a>, <a href="https://docs.btcpayserver.org/Docker/cloudflare-tunnel/" target="_blank">Cloudflare</a> or <a href="https://docs.btcpayserver.org/Deployment/ReverseSSHtunnel/" target="_blank">SSH (advanced)</a>.', 'global_settings', 'btcpay-greenfield-for-woocommerce' ),
-				'placeholder' => esc_attr_x( 'e.g. https://btcpayserver.example.com', 'global_settings', 'btcpay-greenfield-for-woocommerce' ),
+				'placeholder' => esc_attr_x( 'https://mainnet.demo.btcpayserver.org', 'global_settings', 'btcpay-greenfield-for-woocommerce' ),
 				'desc_tip'    => true,
 				'id' => 'btcpay_gf_url'
 			],

--- a/src/Helper/GreenfieldApiHelper.php
+++ b/src/Helper/GreenfieldApiHelper.php
@@ -199,7 +199,7 @@ class GreenfieldApiHelper {
 			$client = new Invoice($config['url'], $config['api_key']);
 			try {
 				$invoice = $client->getInvoice($config['store_id'], $invoiceId);
-				return $invoice->isFullyPaid() || $invoice->isPaidLate();
+				return $invoice->isSettled();
 			} catch (\Throwable $e) {
 				Logger::debug('Exception while checking if invoice settled '. $invoiceId . ': ' . $e->getMessage());
 			}


### PR DESCRIPTION
Fixes #40 
Fixes #41 

- use mainnet.demo.btcpayserver.org as BTCPay Server URL placeholder in settings form
- show a warning on trying to connect over a .local domain and abort 