### PR TITLE
Fix refunds, 

### DIFF
--- a/src/Gateway/AbstractGateway.php
+++ b/src/Gateway/AbstractGateway.php
@@ -193,12 +193,20 @@ abstract class AbstractGateway extends \WC_Payment_Gateway {
 			return new \WP_Error('1', $errNoBtcpayId);
 		}
 
+		$remaining = $order->get_remaining_refund_amount();
+		$totalRefunded = $order->get_total_refunded();
+		$total = $order->get_total();
+		$x = $order->get_refunds();
+
 		// Make sure the refund amount is not greater than the invoice amount.
-		if ($amount > $order->get_remaining_refund_amount()) {
+		// This is done by WC and no need to do it here, refund is already saved at this stage so below won't work.
+		// Leaving it here for future reference.
+		/*if ($amount > $order->get_remaining_refund_amount()) {
 			$errAmount = __METHOD__ . ': the refund amount can not exceed the order amount, aborting. Remaining amount ' . $order->get_remaining_refund_amount();
 			Logger::debug($errAmount);
 			return new \WP_Error('1', $errAmount);
 		}
+		*/
 
 		// Create the payout on BTCPay Server.
 		// Handle Sats-mode.

--- a/src/Gateway/AbstractGateway.php
+++ b/src/Gateway/AbstractGateway.php
@@ -193,11 +193,6 @@ abstract class AbstractGateway extends \WC_Payment_Gateway {
 			return new \WP_Error('1', $errNoBtcpayId);
 		}
 
-		$remaining = $order->get_remaining_refund_amount();
-		$totalRefunded = $order->get_total_refunded();
-		$total = $order->get_total();
-		$x = $order->get_refunds();
-
 		// Make sure the refund amount is not greater than the invoice amount.
 		// This is done by WC and no need to do it here, refund is already saved at this stage so below won't work.
 		// Leaving it here for future reference.


### PR DESCRIPTION
No need to check if refund possible, this seems to be handled by WooCommerce. The order is already updated at the state of processing the refunds, if it fails then it will get rolled back. tldr; no need for us to check if an order got more refunds than initially paid.