### PR TITLE
Fix: Allow InvoiceExpired/Invalid webhooks to bypass order status protection

### DIFF
--- a/src/Gateway/AbstractGateway.php
+++ b/src/Gateway/AbstractGateway.php
@@ -468,6 +468,13 @@ abstract class AbstractGateway extends \WC_Payment_Gateway {
 					wp_die('No order found for this invoiceId.', '', ['response' => 200]);
 				}
 
+				// Abort on multiple orders found.
+				if (count($orders) > 1) {
+					Logger::debug('Found multiple orders for invoiceId: ' . $postData->invoiceId);
+					Logger::debug(print_r($orders, true));
+					wp_die('Multiple orders found for this invoiceId, aborting.');
+				}
+
 				// Only continue if the order payment method contains string "btcpaygf_" to avoid processing other gateways.
 				if (strpos($orders[0]->get_payment_method(), 'btcpaygf_') === false) {
 					Logger::debug('Order payment method does not contain "btcpaygf_", aborting.');
@@ -501,8 +508,12 @@ abstract class AbstractGateway extends \WC_Payment_Gateway {
 		if ($protectedOrders === 'yes') {
 			// Check if the order status is either 'processing' or 'completed'
 			if ($order->has_status(array('processing', 'completed'))) {
-				// Allow BTCPay's own cancellation events through regardless to ensure system self-correction.
-				if (!in_array($webhookData->type, ['InvoiceExpired', 'InvoiceInvalid'])) {
+				// Allow BTCPay's own cancellation/invalidaton events through to ensure system self-correction, 
+				// but only if the order is still assigned to a BTCPay payment method to prevent interference with other gateways.
+				$isCancellation = in_array($webhookData->type, ['InvoiceExpired', 'InvoiceInvalid']);
+				$isBTCPayOrder = strpos($order->get_payment_method(), 'btcpaygf_') !== false;
+
+				if (!($isCancellation && $isBTCPayOrder)) {
 					$note = sprintf(
 						__('Webhook (%s) received from BTCPay, but the order is already processing or completed, skipping to update order status. Please manually check if everything is alright.', 'btcpay-greenfield-for-woocommerce'),
 						$webhookData->type
@@ -676,22 +687,22 @@ abstract class AbstractGateway extends \WC_Payment_Gateway {
 					// Update order meta data with payment methods and transactions.
 					$order->update_meta_data( "BTCPay_{$paymentMethodName}_total_paid", $payment->getTotalPaid() ?? '' );
 					$order->update_meta_data( "BTCPay_{$paymentMethodName}_total_amount", $payment->getAmount() ?? '' );
-					$order->update_meta_data( "BTCPay_{$paymentMethodName}_total_due\", $payment->getDue() ?? '' );
-					$order->update_meta_data( \"BTCPay_{$paymentMethodName}_total_fee\", $payment->getNetworkFee() ?? '' );
-					$order->update_meta_data( \"BTCPay_{$paymentMethodName}_rate\", $payment->getRate() ?? '' );
+					$order->update_meta_data( "BTCPay_{$paymentMethodName}_total_due", $payment->getDue() ?? '' );
+					$order->update_meta_data( "BTCPay_{$paymentMethodName}_total_fee", $payment->getNetworkFee() ?? '' );
+					$order->update_meta_data( "BTCPay_{$paymentMethodName}_rate", $payment->getRate() ?? '' );
 					if ((float) $payment->getRate() > 0.0) {
 						$formattedRate = number_format((float) $payment->getRate(), wc_get_price_decimals(), wc_get_price_decimal_separator(), wc_get_price_thousand_separator());
-						$order->update_meta_data( \"BTCPay_{$paymentMethodName}_rateFormatted\", $formattedRate );
+						$order->update_meta_data( "BTCPay_{$paymentMethodName}_rateFormatted", $formattedRate );
 					}
 
 					// For each actual payment make a separate entry to make sense of it.
 					foreach ($payment->getPayments() as $index => $trx) {
-						$order->update_meta_data( \"BTCPay_{$paymentMethodName}_{$index}_id\", $trx->getTransactionId() ?? '' );
-						$order->update_meta_data( \"BTCPay_{$paymentMethodName}_{$index}_timestamp\", $trx->getReceivedTimestamp() ?? '' );
-						$order->update_meta_data( \"BTCPay_{$paymentMethodName}_{$index}_destination\", $trx->getDestination() ?? '' );
-						$order->update_meta_data( \"BTCPay_{$paymentMethodName}_{$index}_amount\", $trx->getValue() ?? '' );
-						$order->update_meta_data( \"BTCPay_{$paymentMethodName}_{$index}_status\", $trx->getStatus() ?? '' );
-						$order->update_meta_data( \"BTCPay_{$paymentMethodName}_{$index}_networkFee\", $trx->getFee() ?? '' );
+						$order->update_meta_data( "BTCPay_{$paymentMethodName}_{$index}_id", $trx->getTransactionId() ?? '' );
+						$order->update_meta_data( "BTCPay_{$paymentMethodName}_{$index}_timestamp", $trx->getReceivedTimestamp() ?? '' );
+						$order->update_meta_data( "BTCPay_{$paymentMethodName}_{$index}_destination", $trx->getDestination() ?? '' );
+						$order->update_meta_data( "BTCPay_{$paymentMethodName}_{$index}_amount", $trx->getValue() ?? '' );
+						$order->update_meta_data( "BTCPay_{$paymentMethodName}_{$index}_status", $trx->getStatus() ?? '' );
+						$order->update_meta_data( "BTCPay_{$paymentMethodName}_{$index}_networkFee", $trx->getFee() ?? '' );
 					}
 
 					// Save the order.


### PR DESCRIPTION
## Problem
When the `btcpay_gf_protect_order_status` option is enabled, the plugin blindly skips **all** webhook events if an order is in `processing` or `completed` status. 

While the intention is to prevent third-party plugins or accidental race conditions from overwriting a paid status, it currently prevents legitimate system self-correction from BTCPay Server itself. 

Specifically, if an order is mapped to `processing` upon `InvoiceProcessing` (unconfirmed mempool payment), and that payment subsequently fails to confirm, gets RBF'd, or the invoice simply expires, the `InvoiceExpired` webhook is ignored. This leaves the WooCommerce order stuck in `processing` (Paid) forever, even though the funds never arrived.

## Solution
This PR modifies the protection logic to allow `InvoiceExpired` and `InvoiceInvalid` events to pass through regardless of the order's current status. This ensures that the payment processor's own "final word" on a failed payment is always respected, allowing the system to correctly cancel unpaid orders.

## Impact
- Protects the merchant from fulfilling orders where the payment never confirmed.
- Ensures manual "Invalidate" actions taken in the BTCPay dashboard are correctly reflected in WooCommerce.
- Maintains the existing protection against non-BTCPay status interference.