### PR TITLE
Improvements for modal checkout

### DIFF
--- a/btcpay-greenfield-for-woocommerce.php
+++ b/btcpay-greenfield-for-woocommerce.php
@@ -7,7 +7,7 @@
  * Author URI:      https://btcpayserver.org
  * Text Domain:     btcpay-greenfield-for-woocommerce
  * Domain Path:     /languages
- * Version:         2.7.4
+ * Version:         2.7.5
  * Requires PHP:    8.0
  * Tested up to:    6.9
  * Requires at least: 6.2
@@ -27,7 +27,7 @@ use BTCPayServer\WC\Helper\Logger;
 
 defined( 'ABSPATH' ) || exit();
 
-define( 'BTCPAYSERVER_VERSION', '2.7.4' );
+define( 'BTCPAYSERVER_VERSION', '2.7.5' );
 define( 'BTCPAYSERVER_VERSION_KEY', 'btcpay_gf_version' );
 define( 'BTCPAYSERVER_PLUGIN_FILE_PATH', plugin_dir_path( __FILE__ ) );
 define( 'BTCPAYSERVER_PLUGIN_URL', plugin_dir_url(__FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: Bitcoin, Lightning Network, BTCPay Server, WooCommerce, payment gateway
 Requires at least: 5.9
 Tested up to: 6.9
 Requires PHP: 8.0
-Stable tag: 2.7.4
+Stable tag: 2.7.5
 License: MIT
 License URI: https://github.com/btcpayserver/woocommerce-greenfield-plugin/blob/master/license.txt
 
@@ -110,12 +110,14 @@ You'll find extensive documentation and answers to many of your questions on [BT
 
 == Upgrade Notice ==
 
-= 2.7.4 =
-* Fix: Make sure modal checkout event handler does not get attached multiple times
-* Maintenance: Update NodeJS and dependencies to v20
+= 2.7.5 =
+* Fix: Refunds: remove XMR from payment methods to not break refunds
 
 
 == Changelog ==
+= 2.7.5 :: 2026-04-09 =
+* Fix: Refunds: remove XMR from payment methods to not break refunds
+
 = 2.7.4 :: 2026-03-26 =
 * Fix: Make sure modal checkout event handler does not get attached multiple times
 * Maintenance: Update NodeJS and dependencies to v20

--- a/resources/js/frontend/blocksModalCheckout.js
+++ b/resources/js/frontend/blocksModalCheckout.js
@@ -35,6 +35,16 @@ wp.data.subscribe(() => {
 		if (activePM.startsWith('btcpaygf_')) {
 			//console.log('BTCPay is selected');
 
+			// Check for validation errors before proceeding.
+			// This ensures required fields (address, email, etc.) are filled in.
+			const validationStore = wp.data.select(wc.wcBlocksData.VALIDATION_STORE_KEY);
+			if (validationStore && validationStore.hasValidationErrors()) {
+				// Make all validation errors visible to the user.
+				wp.data.dispatch(wc.wcBlocksData.VALIDATION_STORE_KEY).showAllValidationErrors();
+				isProcessingOrder = false;
+				return;
+			}
+
 			// Make sure the order exists and invoice is created.
 			let responseData = blocksProcessOrder(activePM);
 			//console.log(responseData);

--- a/resources/js/frontend/blocksModalCheckout.js
+++ b/resources/js/frontend/blocksModalCheckout.js
@@ -3,6 +3,21 @@
 let isProcessingOrder = false;
 let lastExecutionTime = 0;
 const debounceInterval = 1000;
+let invoiceCreatedForOrder = null;
+
+let originalButtonText = null;
+
+const setButtonProcessing = function (processing) {
+	const textEl = document.querySelector('.wc-block-components-checkout-place-order-button__text');
+	if (!textEl) return;
+	if (processing) {
+		originalButtonText = textEl.textContent;
+		textEl.textContent = BTCPayWP.textProcessingButton || 'Processing…';
+	} else if (originalButtonText) {
+		textEl.textContent = originalButtonText;
+		originalButtonText = null;
+	}
+};
 
 /**
  * Subscribe to the checkout store and listen to place order button event,
@@ -34,6 +49,7 @@ wp.data.subscribe(() => {
 
 		if (activePM.startsWith('btcpaygf_')) {
 			//console.log('BTCPay is selected');
+			setButtonProcessing(true);
 
 			// Check for validation errors before proceeding.
 			// This ensures required fields (address, email, etc.) are filled in.
@@ -51,8 +67,12 @@ wp.data.subscribe(() => {
 			if (responseData) {
 				//console.log('got response: ');
 				//console.log(responseData);
+				// Reset checkout to idle to prevent WooCommerce blocks from also
+				// sending its own REST checkout request (which would call
+				// process_payment a second time and create a duplicate invoice).
+				resetCheckout();
 				blocksShowBTCPayModal(responseData);
-				isProcessingOrder = false;
+				// Keep isProcessingOrder = true while modal is open to prevent duplicate invoices.
 				return false;
 			} else {
 				blocksSubmitError(BTCPayWP.textProcessingError);
@@ -79,6 +99,11 @@ const blocksProcessOrder = function (paymentGateway) {
 	const checkout = wp.data.select(wc.wcBlocksData.CHECKOUT_STORE_KEY);
 	const orderId = checkout.getOrderId();
 
+	// Prevent duplicate invoice creation for the same order.
+	if (orderId && orderId === invoiceCreatedForOrder) {
+		return null;
+	}
+
 	// Prepare form data.
 	let data = {
 		'action': 'btcpaygf_modal_blocks_checkout',
@@ -96,6 +121,7 @@ const blocksProcessOrder = function (paymentGateway) {
 		//console.log(response);
 
 		if (response.data.invoiceId) {
+			invoiceCreatedForOrder = orderId;
 			responseData = response.data;
 		} else {
 			///unblockElement('.woocommerce-checkout-payment');
@@ -126,6 +152,9 @@ const blocksShowBTCPayModal = function (data) {
 
 	if (data.invoiceId !== undefined) {
 		window.btcpay.setApiUrlPrefix(BTCPayWP.apiUrl);
+		window.btcpay.onModalWillEnter(function () {
+			setButtonProcessing(false);
+		});
 		window.btcpay.showInvoice(data.invoiceId);
 	}
 	let invoice_paid = false;
@@ -146,11 +175,15 @@ const blocksShowBTCPayModal = function (data) {
 						break;
 					case 'expired':
 						window.btcpay.hideFrame();
-						submitError(BTCPayWP.textInvoiceExpired);
+						isProcessingOrder = false;
+						invoiceCreatedForOrder = null;
+						blocksSubmitError(BTCPayWP.textInvoiceExpired);
 						break;
 					case 'invalid':
 						window.btcpay.hideFrame();
-						submitError(BTCPayWP.textInvoiceInvalid);
+						isProcessingOrder = false;
+						invoiceCreatedForOrder = null;
+						blocksSubmitError(BTCPayWP.textInvoiceInvalid);
 						break;
 				}
 			}
@@ -159,6 +192,8 @@ const blocksShowBTCPayModal = function (data) {
 				if (invoice_paid === true) {
 					window.location = data.orderCompleteLink;
 				}
+				isProcessingOrder = false;
+				invoiceCreatedForOrder = null;
 				blocksSubmitError(BTCPayWP.textModalClosed);
 			}
 		}
@@ -174,6 +209,7 @@ const blocksShowBTCPayModal = function (data) {
  * @param error_message
  */
 const blocksSubmitError = function (error_message) {
+	setButtonProcessing(false);
 	window.wp.data.dispatch( 'core/notices' )
 		.createErrorNotice(
 			error_message,

--- a/src/Gateway/AbstractGateway.php
+++ b/src/Gateway/AbstractGateway.php
@@ -412,10 +412,14 @@ abstract class AbstractGateway extends \WC_Payment_Gateway {
 		}
 
 		// Register modal script.
+		$scriptDeps = [ 'jquery', 'wp-data' ];
+		if ($isBlockCheckout) {
+			$scriptDeps[] = 'wc-blocks-data-store';
+		}
 		wp_register_script(
 			$scriptName,
 			$scriptFile,
-			[ 'jquery', 'wp-data' ],
+			$scriptDeps,
 			BTCPAYSERVER_VERSION,
 			true
 		);
@@ -434,6 +438,7 @@ abstract class AbstractGateway extends \WC_Payment_Gateway {
 			'textInvoiceInvalid' => _x( 'The invoice is invalid. Please try again, choose a different payment method or contact us if you paid but the payment did not confirm in time.', 'js', 'btcpay-greenfield-for-woocommerce' ),
 			'textModalClosed' => _x( 'Payment aborted by you. Please try again or choose a different payment method.', 'js', 'btcpay-greenfield-for-woocommerce' ),
 			'textProcessingError' => _x( 'Error processing checkout. Please try again or choose another payment option.', 'js', 'btcpay-greenfield-for-woocommerce' ),
+			'textProcessingButton' => _x( 'Processing…', 'js', 'btcpay-greenfield-for-woocommerce' ),
 		] );
 		// Add the registered modal blocks script to frontend.
 		wp_enqueue_script( $scriptName );
@@ -640,6 +645,7 @@ abstract class AbstractGateway extends \WC_Payment_Gateway {
 						sort($pmInvoice);
 						$pm = $this->getPaymentMethods();
 						sort($pm);
+						Logger::debug( 'validInvoiceExists: pmInvoice: ' . print_r($pmInvoice, true) . ' pm: ' . print_r($pm, true) . ' match: ' . ($pm === $pmInvoice ? 'yes' : 'no') );
 						if ($pm === $pmInvoice) {
 							return true;
 						}

--- a/src/Gateway/AbstractGateway.php
+++ b/src/Gateway/AbstractGateway.php
@@ -381,10 +381,28 @@ abstract class AbstractGateway extends \WC_Payment_Gateway {
 		// Load BTCPay modal JS.
 		wp_enqueue_script( 'btcpay_gf_modal_js', $this->apiHelper->url . '/modal/btcpay.js', [], BTCPAYSERVER_VERSION );
 
-		// Get page id of checkout page.
-		$checkoutPageId = wc_get_page_id('checkout');
 		// Check if the checkout page uses the new woocommerce blocks.
-		$isBlockCheckout = has_block( 'woocommerce/checkout' , $checkoutPageId);
+		$isBlockCheckout = false;
+
+		// 1. Try WooCommerce utility (handles block themes with DB-customized templates + page content).
+		if ( class_exists( '\Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils' )
+			&& method_exists( '\Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils', 'is_checkout_block_default' ) ) {
+			$isBlockCheckout = \Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils::is_checkout_block_default();
+		}
+
+		// 2. Fallback: directly check the checkout page content for the block.
+		if ( ! $isBlockCheckout ) {
+			$checkoutPageId = wc_get_page_id( 'checkout' );
+			$isBlockCheckout = $checkoutPageId && has_block( 'woocommerce/checkout', $checkoutPageId );
+		}
+
+		// 3. Block themes with WooCommerce Blocks always use block-based checkout via templates,
+		//    even if the checkout page content doesn't contain the block directly and the
+		//    template hasn't been customized (saved to DB). The WC utility misses this case.
+		if ( ! $isBlockCheckout && function_exists( 'wp_is_block_theme' ) && wp_is_block_theme()
+			&& class_exists( '\Automattic\WooCommerce\Blocks\Package' ) ) {
+			$isBlockCheckout = true;
+		}
 		if ($isBlockCheckout) {
 			$scriptName = 'btcpay_gf_modal_blocks_checkout';
 			$scriptFile = BTCPAYSERVER_PLUGIN_URL . 'assets/js/frontend/blocksModalCheckout.js';


### PR DESCRIPTION
1) On blocks based checkout, make sure the modal only shows when there are no validation errors. It could cause orders to get submitted without customer data.

2) On some edge cases especially when you migrated from old legacy checkout to new checkout blocks it could happen that the blocks detection did not work and loaded the wrong modal checkout javascript file, making modal based checkout not work. 

3) Seems that with some WooCommerce update the behaviour changed. It created multiple invoices with modal enabled on blocks checkout; 

4) also fixed when closing the modal it was not possible to re-trigger it when switching payment methods or just closing the modal