### PR TITLE
Add refund links to order details page.

### DIFF
--- a/btcpay-greenfield-for-woocommerce.php
+++ b/btcpay-greenfield-for-woocommerce.php
@@ -377,12 +377,14 @@ class BTCPayServerWCPlugin {
 		}
 
 		$checkoutLink = self::getCheckoutLink($order);
+		$refundLinks = self::getRefundLinks($order);
 
 		echo "
 		<section class='woocommerce-order-payment-status'>
 		    <h2 class='woocommerce-order-payment-status-title'>{$title}</h2>
 		    <p><strong>{$statusDesc}</strong></p>
 		    {$checkoutLink}
+		    {$refundLinks}
 		</section>
 		";
 	}
@@ -402,7 +404,9 @@ class BTCPayServerWCPlugin {
 		}
 
 		$checkoutLink = self::getCheckoutLink($order);
-		if ($checkoutLink === '') {
+		$refundLinks = self::getRefundLinks($order);
+
+		if ($checkoutLink === '' && $refundLinks === '') {
 			return;
 		}
 
@@ -411,6 +415,7 @@ class BTCPayServerWCPlugin {
 		<section class='woocommerce-order-payment-status'>
 		    <h2 class='woocommerce-order-payment-status-title'>{$title}</h2>
 		    {$checkoutLink}
+		    {$refundLinks}
 		</section>
 		";
 	}
@@ -428,6 +433,35 @@ class BTCPayServerWCPlugin {
 		$label = esc_html_x('BTCPay Invoice:', 'btcpay-greenfield-for-woocommerce');
 		$escapedUrl = esc_url($url);
 		return "<p>{$label} <a href='{$escapedUrl}' target='_blank' rel='noreferrer'>{$escapedUrl}</a></p>";
+	}
+
+	/**
+	 * Returns refund link(s) HTML if the refund visibility setting is enabled.
+	 */
+	private static function getRefundLinks(\WC_Order $order): string
+	{
+		if (get_option('btcpay_gf_refund_note_visible') !== 'yes') {
+			return '';
+		}
+
+		$refunds = $order->get_meta('BTCPay_refund', false);
+		if (empty($refunds)) {
+			return '';
+		}
+
+		$html = '';
+		$label = esc_html_x('Refund:', 'btcpay-greenfield-for-woocommerce');
+		foreach ($refunds as $refund) {
+			$value = $refund->value;
+			if (preg_match('/Link:\s*(.+)/i', $value, $matches)) {
+				$url = esc_url(trim($matches[1]));
+				if (!empty($url)) {
+					$html .= "<p>{$label} <a href='{$url}' target='_blank' rel='noreferrer'>{$url}</a></p>";
+				}
+			}
+		}
+
+		return $html;
 	}
 
 	/**

--- a/btcpay-greenfield-for-woocommerce.php
+++ b/btcpay-greenfield-for-woocommerce.php
@@ -377,14 +377,12 @@ class BTCPayServerWCPlugin {
 		}
 
 		$checkoutLink = self::getCheckoutLink($order);
-		$refundLinks = self::getRefundLinks($order);
 
 		echo "
 		<section class='woocommerce-order-payment-status'>
 		    <h2 class='woocommerce-order-payment-status-title'>{$title}</h2>
 		    <p><strong>{$statusDesc}</strong></p>
 		    {$checkoutLink}
-		    {$refundLinks}
 		</section>
 		";
 	}

--- a/src/Admin/GlobalSettings.php
+++ b/src/Admin/GlobalSettings.php
@@ -260,7 +260,7 @@ class GlobalSettings extends \WC_Settings_Page {
 				'title' => __( 'Customer visible refunds', 'btcpay-greenfield-for-woocommerce' ),
 				'type' => 'checkbox',
 				'default' => 'no',
-				'desc' => _x( 'If enabled, it will show the order refund note also to the customer and trigger an email to customer with the refund link.', 'global_settings', 'btcpay-greenfield-for-woocommerce' ),
+				'desc' => _x( 'If enabled, it will show the order refund note also to the customer, trigger an email to customer with the refund link, and display refund links on the customer order details page.', 'global_settings', 'btcpay-greenfield-for-woocommerce' ),
 				'id' => 'btcpay_gf_refund_note_visible'
 			],
 			'debug' => [


### PR DESCRIPTION
adds refund links on the order details page if the customer refunds notes setting: "Customer visible refunds" is enabled.